### PR TITLE
Corrected the describe function in GerritChangeSource.

### DIFF
--- a/master/buildbot/changes/gerritchangesource.py
+++ b/master/buildbot/changes/gerritchangesource.py
@@ -295,17 +295,17 @@ class GerritChangeSource(base.ChangeSource):
         branch = ""
 
         if self.project is not None:
-            project = "project %s" % self.project
+            project = "project '%s'" % self.project
         else:
             project = "all projects"
 
         if self.branch is not None:
-           branch = "branch %s" % self.branch
+           branch = "branch '%s'" % self.branch
         else:
            branch = "all branches"
 
         if not self.process:
             status = "[NOT CONNECTED - check log]"
-        msg = ("GerritChangeSource watching the remote "
+        msg = ("GerritChangeSource watching %s (%s) in remote "
                "Gerrit repository %s@%s %s")
         return msg % (project, branch, self.username, self.gerritserver, status)


### PR DESCRIPTION
Fixed the format of the the message string in the
describe function of the GerritChangeSource.

Commit 452dba5 introduced the problem. This commit
can be squashed during a rebase.

Signed-off-by: Giuseppe Di Natale dinatale2@llnl.gov
