### PR TITLE
Resolved an issue where slave can be None during build cleanup.

### DIFF
--- a/master/buildbot/process/builder.py
+++ b/master/buildbot/process/builder.py
@@ -302,12 +302,12 @@ class Builder(config.ReconfigurableServiceMixin,
         cleanups = []
 
         def run_cleanups():
-            try:
-                while cleanups:
-                    fn = cleanups.pop()
+            while cleanups:
+                fn = cleanups.pop()
+                try:
                     fn()
-            except:
-                log.err(failure.Failure(), "while running %r" % (run_cleanups,))
+                except:
+                    log.err(failure.Failure(), "while running %r" % (run_cleanups,))
 
         # the last cleanup we want to perform is to update the big
         # status based on any other cleanup
@@ -319,7 +319,7 @@ class Builder(config.ReconfigurableServiceMixin,
 
         # set up locks
         build.setLocks(self.config.locks)
-        cleanups.append(lambda: slavebuilder.slave.releaseLocks())
+        cleanups.append(lambda: slavebuilder.slave.releaseLocks() if slavebuilder.slave is not None else None)
 
         if len(self.config.env) > 0:
             build.setSlaveEnvironment(self.config.env)


### PR DESCRIPTION
In Builder._startBuildFor, it is possible for slavebuilder.slave
to be None. Introduced a check for None. Also, I changed the exception
handling in run_cleanups. As much cleanup as possible should happen
instead of bailing on the first error.

Signed-off-by: Giuseppe Di Natale dinatale2@llnl.gov
