### PR TITLE
Allow independant EC2 price_multiplier or max_spot_price usag

### DIFF
--- a/master/buildbot/buildslave/ec2.py
+++ b/master/buildbot/buildslave/ec2.py
@@ -363,7 +363,7 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
                 (self.__class__.__name__, self.slavename,
                  instance.id, goal, duration // 60, duration % 60))
 
-    def _request_spot_instance(self):
+    def _bid_price_from_spot_price_history(self):
         timestamp_yesterday = time.gmtime(int(time.time() - 86400))
         spot_history_starttime = time.strftime(
             '%Y-%m-%dT%H:%M:%SZ', timestamp_yesterday)
@@ -381,6 +381,10 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
             target_price = 0.02
         else:
             target_price = (price_sum / price_count) * self.price_multiplier
+        return target_price
+
+    def _request_spot_instance(self):
+        target_price = self._bid_price_from_spot_price_history()
         if target_price > self.max_spot_price:
             log.msg('%s %s calculated spot price %0.2f exceeds '
                     'configured maximum of %0.2f' %

--- a/master/docs/manual/cfg-buildslaves.rst
+++ b/master/docs/manual/cfg-buildslaves.rst
@@ -364,6 +364,11 @@ Additionally, you may want to specify ``max_spot_price`` and ``price_multiplier`
 This example would attempt to create a m1.large spot instance in the us-west-2b region costing no more than $0.09/hour.
 The spot prices for that region in the last 24 hours will be averaged and multiplied by the ``price_multiplier`` parameter, then a spot request will be sent to Amazon with the above details.
 If the spot request is rejected, an error message will be logged with the final status.
+If the multiple exceeds the ``max_spot_price``, the bid price will be the ``max_spot_price``.
+
+Either ``max_spot_price`` or ``price_multiplier``, but not both, may be None.
+If ``price_multiplier`` is None, then no historical price information is retrieved; the bid price is simply the specified ``max_spot_price``.
+If the ``max_spot_price`` is None, then the multiple of the historical average spot prices is used as the bid price with no limit.
 
 .. index::
    libvirt


### PR DESCRIPTION
Allow independant EC2 price_multiplier or max_spot_price usage

Change the EC2LatentBuildSlave to allow the use of just one
of either max_spot_price or price_multiplier.  In other words,
either value can be set to None so that only the other value
is used.  When spot instances are used, at least one of those two
parameters must be set.

If only max_spot_price is set, that is the value that is used
as the bid price.  There is not need to look up the historical
bid prices in that case.  It seems likely that in the real world
most people will want to set the maximum price they are willing
to pay.  Artificially bidding lower than one is willing to pay
based on historical information is probably not a very common use
case.

Also, change the logic to use as the bid price the minumum of either
the multiple of the historical average or the max_spot_price.  The
previous behavior was to raise an exception if the multiple was in
excess of the max_spot_price.  That doesn't make much sense.  The
historical average tells us little about the price _now_, so it probably
never makes sense to abort early without at least making an attempt
to substantiate with the max_spot_price.
