### PR TITLE
Add instance ID to build properties

### DIFF
--- a/master/buildbot/buildslave/ec2.py
+++ b/master/buildbot/buildslave/ec2.py
@@ -432,6 +432,7 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
                 else:
                     raise
         if self.instance.state == RUNNING:
+            self.properties.setProperty("instance", self.instance.id, "BuildSlave")
             self.output = self.instance.get_console_output()
             minutes = duration // 60
             seconds = duration % 60


### PR DESCRIPTION
The EC2 instance ID will now be automatically added as a build property
by the build slave. The instance ID will be necessary for various features in
the future such as collecting console logs.

Signed-off-by: Brian Behlendorf behlendorf1@llnl.gov
