### PR TITLE
Add logEnviron flag to MasterShellCommand

### DIFF
--- a/master/buildbot/steps/master.py
+++ b/master/buildbot/steps/master.py
@@ -48,7 +48,7 @@ class MasterShellCommand(BuildStep):
     def __init__(self, command,
                  description=None, descriptionDone=None, descriptionSuffix=None,
                  env=None, path=None, usePTY=0, interruptSignal="KILL",
-                 **kwargs):
+                 logEnviron=True, **kwargs):
         BuildStep.__init__(self, **kwargs)
 
         self.command = command
@@ -68,6 +68,7 @@ class MasterShellCommand(BuildStep):
         self.path = path
         self.usePTY = usePTY
         self.interruptSignal = interruptSignal
+        self.logEnviron = logEnviron
 
     class LocalPP(ProcessProtocol):
 
@@ -153,7 +154,8 @@ class MasterShellCommand(BuildStep):
                                            "lists; key '%s' is incorrect" % (key,))
                     newenv[key] = p.sub(subst, env[key])
             env = newenv
-        stdio_log.addHeader(" env: %r\n" % (env,))
+        if self.logEnviron:
+            stdio_log.addHeader(" env: %r\n" % (env,))
 
         # TODO add a timeout?
         self.process = reactor.spawnProcess(self.LocalPP(self), argv[0], argv,


### PR DESCRIPTION
Added the logEnviron flag to the MasterShellCommand
step. The master may have variables in it's environment
(such as AWS credentials) which we do not want to leak
into a log.

Signed-off-by: Giuseppe Di Natale dinatale2@llnl.gov
