### PR TITLE
Handle missing instances during termination

### DIFF
--- a/master/buildbot/buildslave/ec2.py
+++ b/master/buildbot/buildslave/ec2.py
@@ -335,14 +335,22 @@ class EC2LatentBuildSlave(AbstractLatentBuildSlave):
         try:
             instance.update()
         except boto.exception.EC2ResponseError, e:
-            log.msg('%s %s cannot find instance %s to terminate' %
+            log.msg('%s %s cannot find instance %s to update for termination' %
                     (self.__class__.__name__, self.slavename, instance.id))
             if e.error_code == 'InvalidInstanceID.NotFound':
                 return
             else:
                 raise
         if instance.state not in (SHUTTINGDOWN, TERMINATED):
-            instance.terminate()
+            try:
+                instance.terminate()
+            except boto.exception.EC2ResponseError, e:
+                log.msg('%s %s cannot find instance %s to terminate' %
+                    (self.__class__.__name__, self.slavename, instance.id))
+                if e.error_code == 'InvalidInstanceID.NotFound':
+                    return
+                else:
+                    raise
             log.msg('%s %s terminating instance %s' %
                     (self.__class__.__name__, self.slavename, instance.id))
         duration = 0


### PR DESCRIPTION
Added exception handling in EC2 slave termination to handle
when an instance is not found. It is possible for instances
to be lost (ex. spot instances) which can cause an EC2 slave
to fail during termination. Termination should be best effort,
if the instance is missing, that must mean it is terminated.

Signed-off-by: Giuseppe Di Natale dinatale2@llnl.gov
